### PR TITLE
feat(python): add challenges and dictionaries & tuples drafts

### DIFF
--- a/_data/python_training_editors.yml
+++ b/_data/python_training_editors.yml
@@ -1,6 +1,53 @@
 introduction-hello-world: |-
   print("Hello, World!")
 
+dicts-tuples-dict-vs-list: |-
+  # Say you want to track the scores of three players.
+  # With a list, you have to remember which index belongs to which player.
+  scores_list = [92, 78, 85]
+  print(scores_list[0])   # whose score is this? you have to remember: alice
+
+  # With a dict, the name is right there in the data.
+  scores_dict = {
+      "alice": 92,
+      "bob":   78,
+      "carol": 85,
+  }
+  print(scores_dict["alice"])   # no guessing required
+
+  # Adding a fourth player with a list means remembering the new index.
+  scores_list.append(91)   # index 3 -- is that dave? who knows
+
+  # With a dict the key tells you everything.
+  scores_dict["dave"] = 91
+  print(scores_dict)
+
+dicts-tuples-dict-phonebook: |-
+  # A phone book is a classic dict use case:
+  # you know the name, you want the number.
+  phonebook = {
+      "Alice":   "555-1234",
+      "Bob":     "555-5678",
+      "Carol":   "555-9999",
+  }
+
+  # Look up a number by name
+  print(phonebook["Alice"])
+
+  # Add a new contact
+  phonebook["Dave"] = "555-0001"
+
+  # Check if someone is in the book before looking them up
+  name = "Eve"
+  if name in phonebook:
+      print(phonebook[name])
+  else:
+      print(f"{name} is not in the phonebook")
+
+  # Remove a contact
+  phonebook.pop("Bob")
+  print(phonebook)
+
 basics-variables: |-
   name = "Alice"
   age = 30
@@ -173,3 +220,282 @@ basics-functions-defaults: |-
 
   print(power(3))     # 3 squared = 9
   print(power(3, 3))  # 3 cubed = 27
+
+dicts-tuples-tuple-basics: |-
+  # Tuples use parentheses instead of square brackets
+  point = (10, 20)
+  rgb = (255, 128, 0)
+  single = (42,)   # trailing comma makes it a tuple, not just (42)
+
+  print(point)
+  print(type(point))
+  print(type(single))
+
+  # Indexing works the same as lists
+  print(point[0])   # 10
+  print(point[1])   # 20
+  print(rgb[-1])    # last item: 0
+
+dicts-tuples-tuple-unpack: |-
+  # Unpacking assigns each item to a variable in one step
+  point = (10, 20)
+  x, y = point
+  print(x)   # 10
+  print(y)   # 20
+
+  # Works with any iterable -- functions often return tuples this way
+  def min_max(numbers):
+      return (min(numbers), max(numbers))
+
+  low, high = min_max([3, 1, 7, 2, 9])
+  print(low)    # 1
+  print(high)   # 9
+
+  # Classic swap -- no temp variable needed
+  a = "hello"
+  b = "world"
+  a, b = b, a
+  print(a)   # world
+  print(b)   # hello
+
+dicts-tuples-tuple-vs-list: |-
+  # Lists are for collections that change
+  cart = ["apple", "banana"]
+  cart.append("cherry")
+  cart.remove("banana")
+  print(cart)
+
+  # Tuples are for records that should not change
+  location = (51.5074, -0.1278)   # latitude, longitude of London
+  # location[0] = 0  # this would raise a TypeError -- tuples are immutable
+
+  # Tuples can be used as dictionary keys because they're immutable
+  distances = {
+      (0, 0): 0,
+      (3, 4): 5,
+  }
+  print(distances[(3, 4)])
+
+dicts-tuples-dict-create: |-
+  # Curly braces, key: value pairs
+  person = {
+      "name": "Alice",
+      "age": 30,
+      "city": "London",
+  }
+  print(person)
+
+  # Add a new key by assigning to it
+  person["email"] = "alice@example.com"
+  print(person)
+
+  # Keys can be any immutable type -- strings are most common
+  config = {}
+  config["debug"] = True
+  config["max_retries"] = 3
+  print(config)
+
+dicts-tuples-dict-access: |-
+  person = {"name": "Alice", "age": 30}
+
+  # Direct access -- raises KeyError if the key doesn't exist
+  print(person["name"])
+
+  # .get() returns None if the key doesn't exist -- no crash
+  print(person.get("age"))
+  print(person.get("email"))          # None
+  print(person.get("email", "n/a"))   # supply a default value
+
+dicts-tuples-dict-modify: |-
+  person = {"name": "Alice", "age": 30, "city": "London"}
+
+  # Update an existing value
+  person["age"] = 31
+  print(person)
+
+  # Remove a key with del
+  del person["city"]
+  print(person)
+
+  # .pop() removes and returns the value
+  age = person.pop("age")
+  print(age)      # 31
+  print(person)   # {"name": "Alice"}
+
+dicts-tuples-dict-iterate-keys: |-
+  scores = {"alice": 92, "bob": 78, "carol": 85}
+
+  # Iterating a dict directly gives you its keys
+  for name in scores:
+      print(name)
+
+  # .keys() is explicit and means the same thing
+  for name in scores.keys():
+      print(name)
+
+dicts-tuples-dict-iterate-values: |-
+  scores = {"alice": 92, "bob": 78, "carol": 85}
+
+  for score in scores.values():
+      print(score)
+
+  # Practical use: total up all values
+  total = 0
+  for score in scores.values():
+      total += score
+  print(f"Average: {total / len(scores):.1f}")
+
+dicts-tuples-dict-iterate-items: |-
+  scores = {"alice": 92, "bob": 78, "carol": 85}
+
+  # .items() gives you (key, value) pairs -- unpack them directly
+  for name, score in scores.items():
+      print(f"{name}: {score}")
+
+dicts-tuples-dict-membership: |-
+  person = {"name": "Alice", "age": 30}
+
+  # Check if a key exists
+  print("name" in person)     # True
+  print("email" in person)    # False
+  print("email" not in person) # True
+
+  # Useful for safe access patterns
+  if "email" in person:
+      print(person["email"])
+  else:
+      print("no email on file")
+
+dicts-tuples-dict-nested: |-
+  # A dict whose values are themselves dicts
+  users = {
+      "alice": {"age": 30, "role": "admin"},
+      "bob":   {"age": 25, "role": "viewer"},
+  }
+
+  # Access a nested value: outer key first, then inner key
+  print(users["alice"]["role"])    # admin
+  print(users["bob"]["age"])       # 25
+
+  # Iterate over nested dicts
+  for username, info in users.items():
+      print(f"{username} is a {info['role']}")
+
+challenges-fizzbuzz-starter: |-
+  # FizzBuzz
+  # Loop through numbers 1 to 20.
+  # Print "Fizz" if the number is divisible by 3.
+  # Print "Buzz" if the number is divisible by 5.
+  # Print "FizzBuzz" if divisible by both.
+  # Otherwise print the number itself.
+
+  for i in range(1, 21):
+      # TODO: fill in the conditions
+      pass
+
+challenges-fizzbuzz-solution-a: |-
+  # Approach A: if/elif/else chain
+  # Check the combined case first, then each individually.
+  for i in range(1, 21):
+      if i % 3 == 0 and i % 5 == 0:
+          print("FizzBuzz")
+      elif i % 3 == 0:
+          print("Fizz")
+      elif i % 5 == 0:
+          print("Buzz")
+      else:
+          print(i)
+
+challenges-fizzbuzz-solution-b: |-
+  # Approach B: build the output string, print the number as fallback
+  # Each condition appends to a result string independently.
+  for i in range(1, 21):
+      result = ""
+      if i % 3 == 0:
+          result += "Fizz"
+      if i % 5 == 0:
+          result += "Buzz"
+      print(result if result else i)
+
+challenges-reverse-starter: |-
+  numbers = [1, 2, 3, 4, 5]
+
+  # Reverse the list and print each number on its own line.
+  # Try to think of more than one way to do it.
+
+challenges-reverse-solution-a: |-
+  # Approach A: slicing
+  # [::-1] steps through the list backwards in one go.
+  numbers = [1, 2, 3, 4, 5]
+  reversed_numbers = numbers[::-1]
+  for n in reversed_numbers:
+      print(n)
+
+challenges-reverse-solution-b: |-
+  # Approach B: loop with range() counting backwards
+  # Build a new list by walking the indexes from the end.
+  numbers = [1, 2, 3, 4, 5]
+  result = []
+  for i in range(len(numbers) - 1, -1, -1):
+      result.append(numbers[i])
+  for n in result:
+      print(n)
+
+challenges-grade-starter: |-
+  def get_grade(score):
+      # Return the letter grade for a given score (0-100).
+      # 90+  -> "A"
+      # 80+  -> "B"
+      # 70+  -> "C"
+      # 60+  -> "D"
+      # else -> "F"
+      pass  # replace this with your code
+
+  # Test your function
+  print(get_grade(95))
+  print(get_grade(82))
+  print(get_grade(74))
+  print(get_grade(61))
+  print(get_grade(45))
+
+challenges-grade-solution-a: |-
+  # Approach A: if/elif/else chain
+  def get_grade(score):
+      if score >= 90:
+          return "A"
+      elif score >= 80:
+          return "B"
+      elif score >= 70:
+          return "C"
+      elif score >= 60:
+          return "D"
+      else:
+          return "F"
+
+  print(get_grade(95))
+  print(get_grade(82))
+  print(get_grade(74))
+  print(get_grade(61))
+  print(get_grade(45))
+
+challenges-grade-solution-b: |-
+  # Approach B: thresholds in a list, loop to find the grade
+  # Adding a new grade band means adding one item to the list,
+  # not writing a new elif branch.
+  def get_grade(score):
+      thresholds = [
+          (90, "A"),
+          (80, "B"),
+          (70, "C"),
+          (60, "D"),
+      ]
+      for minimum, grade in thresholds:
+          if score >= minimum:
+              return grade
+      return "F"
+
+  print(get_grade(95))
+  print(get_grade(82))
+  print(get_grade(74))
+  print(get_grade(61))
+  print(get_grade(45))

--- a/_drafts/2026-03-13-python-challenges.md
+++ b/_drafts/2026-03-13-python-challenges.md
@@ -1,0 +1,180 @@
+---
+title: Python Challenges
+author: xransum
+date: 2026-03-13 10:00:00 -0500
+categories:
+  - Tutorial
+tags:
+  - learning
+  - python
+pin: false
+image:
+  path: /commons/python-code-logo.png
+  lqip: null
+  alt: null
+---
+
+{% include embed/python-training/pyscript-loader.html %}
+
+## Overview
+
+You've got the building blocks. Now put them to use.
+
+Each challenge below gives you a problem, the expected output, and a starter editor to work in. There's no single right answer -- if your code produces the correct output, it's correct. Once you're done (or if you're stuck), expand the solution to see two different approaches and how they compare.
+
+---
+
+## Challenge 1: FizzBuzz
+
+Loop through the numbers 1 to 20. For each number:
+
+- Print `"Fizz"` if it is divisible by 3
+- Print `"Buzz"` if it is divisible by 5
+- Print `"FizzBuzz"` if it is divisible by both
+- Otherwise print the number itself
+
+**Expected output:**
+
+```
+1
+2
+Fizz
+4
+Buzz
+Fizz
+7
+8
+Fizz
+Buzz
+11
+Fizz
+13
+14
+FizzBuzz
+16
+17
+Fizz
+19
+Buzz
+```
+
+Give it a shot:
+
+{% include embed/python-training/python-editor.html id='challenges-fizzbuzz-starter' source='challenges-fizzbuzz-starter' %}
+
+<details class="spoiler">
+<summary>Show solution</summary>
+
+<p class="spoiler-section">Approach A -- if/elif/else chain</p>
+
+Check the combined case first, then each condition individually. The order matters: if you checked `% 3` first you'd print "Fizz" for 15 before ever reaching the "FizzBuzz" branch.
+
+{% include embed/python-training/python-editor.html id='challenges-fizzbuzz-solution-a' source='challenges-fizzbuzz-solution-a' %}
+
+<p class="spoiler-section">Approach B -- build a result string</p>
+
+Each condition appends to a string independently. Because both `% 3` and `% 5` run on every iteration, "Fizz" and "Buzz" combine into "FizzBuzz" automatically -- no special case needed.
+
+{% include embed/python-training/python-editor.html id='challenges-fizzbuzz-solution-b' source='challenges-fizzbuzz-solution-b' %}
+
+<p class="spoiler-note">Approach A is easier to read at a glance. Approach B is shorter and handles the combined case without an explicit check -- a small example of letting logic do the work instead of spelling it out.</p>
+
+</details>
+
+---
+
+## Challenge 2: Reverse a List
+
+Given the list below, print each number on its own line in reverse order -- without just calling `reversed()` or `.reverse()`.
+
+```python
+numbers = [1, 2, 3, 4, 5]
+```
+
+**Expected output:**
+
+```
+5
+4
+3
+2
+1
+```
+
+Give it a shot:
+
+{% include embed/python-training/python-editor.html id='challenges-reverse-starter' source='challenges-reverse-starter' %}
+
+<details class="spoiler">
+<summary>Show solution</summary>
+
+<p class="spoiler-section">Approach A -- slicing</p>
+
+`[::-1]` steps through the list from the last index to the first. Concise and idiomatic Python.
+
+{% include embed/python-training/python-editor.html id='challenges-reverse-solution-a' source='challenges-reverse-solution-a' %}
+
+<p class="spoiler-section">Approach B -- loop with range() counting backwards</p>
+
+`range(len(numbers) - 1, -1, -1)` generates indexes from the last position down to 0. More explicit -- you can see exactly what's happening at each step.
+
+{% include embed/python-training/python-editor.html id='challenges-reverse-solution-b' source='challenges-reverse-solution-b' %}
+
+<p class="spoiler-note">Both produce the same output. The slicing approach is more concise and what most Python programmers would reach for. The loop approach makes the mechanics visible -- which is worth understanding even if you end up using slicing in practice. Neither is wrong.</p>
+
+</details>
+
+---
+
+## Challenge 3: Grade Calculator
+
+Write a function called `get_grade` that takes a score (0-100) and returns the corresponding letter grade:
+
+| Score | Grade |
+|-------|-------|
+| 90+   | A     |
+| 80+   | B     |
+| 70+   | C     |
+| 60+   | D     |
+| below 60 | F  |
+
+**Expected output:**
+
+```
+A
+B
+C
+D
+F
+```
+
+Give it a shot:
+
+{% include embed/python-training/python-editor.html id='challenges-grade-starter' source='challenges-grade-starter' %}
+
+<details class="spoiler">
+<summary>Show solution</summary>
+
+<p class="spoiler-section">Approach A -- if/elif/else chain</p>
+
+Straightforward and easy to read. Each condition maps directly to a row in the table above.
+
+{% include embed/python-training/python-editor.html id='challenges-grade-solution-a' source='challenges-grade-solution-a' %}
+
+<p class="spoiler-section">Approach B -- thresholds in a list</p>
+
+The grade boundaries live in a list of pairs. The function loops through them and returns the first grade whose minimum the score meets. Adding a new grade band means adding one line to the list -- not a new `elif`.
+
+{% include embed/python-training/python-editor.html id='challenges-grade-solution-b' source='challenges-grade-solution-b' %}
+
+<p class="spoiler-note">Approach A is probably where your head went first, and there's nothing wrong with it. Approach B uses a list of pairs to drive the logic. When you find yourself writing a long chain of nearly-identical conditions, it's often a sign the data belongs in a list.</p>
+
+</details>
+
+---
+
+## Conclusion
+
+Three challenges, and likely more than three solutions between you and the two examples. That's the point -- there's rarely one right way to write a program. What matters is that your code is correct, readable, and you understand why it works.
+
+The more you write, the more your instincts about which approach fits a situation will sharpen. Keep experimenting.

--- a/_drafts/2026-03-13-python-dicts-and-tuples.md
+++ b/_drafts/2026-03-13-python-dicts-and-tuples.md
@@ -1,0 +1,181 @@
+---
+title: Python Dictionaries and Tuples
+author: xransum
+date: 2026-03-13 12:00:00 -0500
+categories:
+  - Tutorial
+tags:
+  - learning
+  - python
+pin: false
+image:
+  path: /commons/python-code-logo.png
+  lqip: null
+  alt: null
+---
+
+{% include embed/python-training/pyscript-loader.html %}
+
+## Overview
+
+You already know lists. They're great for ordered collections of things -- a shopping cart, a sequence of numbers, a set of results. But they're not the right tool for every job.
+
+This post covers two more data structures. First **dictionaries** -- the most important data structure in Python, and the one you'll use constantly. Then **tuples** -- which you'll actually encounter inside dictionaries before we've formally introduced them, so the order makes sense.
+
+---
+
+## Dictionaries
+
+Here's a problem. You're tracking the scores of three players. You could use a list:
+
+```python
+scores = [92, 78, 85]
+```
+
+But now you have to remember that index `0` is Alice, index `1` is Bob, and index `2` is Carol. That's fine with three players. With thirty it's a mess. And if you ever sort the list or insert someone in the middle, all your indexes shift.
+
+A dictionary solves this by letting you use names as keys instead of positions:
+
+```python
+scores = {
+    "alice": 92,
+    "bob":   78,
+    "carol": 85,
+}
+```
+
+Now you look up Alice by name. The data is self-describing. You don't need to remember any indexes.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-vs-list' source='dicts-tuples-dict-vs-list' %}
+
+This is the core idea behind dictionaries: **when you need to look something up by a meaningful name rather than a position, use a dict.**
+
+A phone book is the classic example. You know the person's name, you want their number. A list of phone numbers with no names attached is useless. A dict with names as keys is exactly the right structure.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-phonebook' source='dicts-tuples-dict-phonebook' %}
+
+You'll reach for a dict any time your data has this shape: there's a label (the key) and a piece of information attached to it (the value). User profiles, config settings, word counts, API responses -- they all fit this pattern.
+
+Keys must be unique and immutable. Strings are the most common choice. Values can be anything: strings, numbers, lists, other dicts.
+
+### Creating and Adding Keys
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-create' source='dicts-tuples-dict-create' %}
+
+You don't have to define all keys upfront. Assigning to a key that doesn't exist yet just creates it.
+
+### Accessing Values
+
+There are two ways to read a value. They behave differently when the key doesn't exist -- and that difference matters.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-access' source='dicts-tuples-dict-access' %}
+
+`d["key"]` crashes with a `KeyError` if the key isn't there. `d.get("key")` returns `None` instead -- or a default you supply. Use `.get()` any time you're not certain the key exists. It's the safer habit.
+
+### Modifying a Dictionary
+
+You can update a value, add a new key, or remove one entirely.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-modify' source='dicts-tuples-dict-modify' %}
+
+`del` removes the key and you're done with it. `.pop()` removes it and hands the value back -- useful when you want to take something out of the dict and use it at the same time.
+
+### Checking if a Key Exists
+
+Before accessing a key you're not sure about, check with `in` -- the same operator you already know from lists.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-membership' source='dicts-tuples-dict-membership' %}
+
+This pattern -- check first, then access -- is how you avoid `KeyError` crashes without needing `.get()`.
+
+### Iterating Over a Dictionary
+
+You'll often need to go through every entry in a dict. There are three ways, each giving you something different.
+
+**Keys only** -- useful when you just need the names:
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-iterate-keys' source='dicts-tuples-dict-iterate-keys' %}
+
+**Values only** -- useful when you only care about the data, not the labels:
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-iterate-values' source='dicts-tuples-dict-iterate-values' %}
+
+**Keys and values together** -- the one you'll use most. `.items()` gives you both at once, and you can unpack them directly in the `for` line:
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-iterate-items' source='dicts-tuples-dict-iterate-items' %}
+
+`for name, score in scores.items()` is idiomatic Python. Get comfortable with it -- you'll write it constantly.
+
+Notice what `.items()` is doing: it's giving you each entry as a pair -- a key and a value bound together. That pair has a name in Python. It's called a tuple. We'll cover those properly in a moment, but you've already been using them.
+
+### Nested Dictionaries
+
+A dict's values can be anything, including other dicts. This is how you represent a record with multiple fields -- a user profile, a config block, a row from a database.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-dict-nested' source='dicts-tuples-dict-nested' %}
+
+You chain keys to go deeper: `users["alice"]["role"]` -- get Alice's entry first (a dict), then get the role from that. This pattern shows up everywhere once you start working with real data.
+
+Keep nesting reasonable. Two levels is common. Three is occasionally necessary. Deeper than that and the data usually wants to be restructured.
+
+### The Connection to Objects
+
+Every Python object stores its attributes in a dictionary internally. When you write `person.name`, Python is essentially doing `person.__dict__["name"]` behind the scenes.
+
+This is why dicts are worth understanding deeply before you get to classes. Objects aren't a new concept built on top of dicts -- they're a friendlier interface to the same underlying structure. When you get there, it'll feel familiar.
+
+---
+
+## Tuples
+
+You've already seen tuples without knowing it. When you call `.items()` on a dict, each entry you get back -- `("alice", 92)`, `("bob", 78)` -- is a tuple. And back in the challenges post, the grade thresholds list was full of them: `(90, "A")`, `(80, "B")`.
+
+A tuple is an ordered sequence, just like a list. The difference is that it's **immutable** -- once created, it can't be changed. No appending, no removing, no replacing items in place.
+
+```python
+point = (10, 20)
+rgb = (255, 128, 0)
+```
+
+Parentheses instead of square brackets. Simple on the surface -- but the immutability is what makes it a distinct tool.
+
+### Indexing
+
+Indexing works exactly like lists: zero-based, negatives count from the end.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-tuple-basics' source='dicts-tuples-tuple-basics' %}
+
+> Watch the single-item tuple: `(42,)` not `(42)`. Without the trailing comma, Python sees parentheses around a number -- not a tuple.
+{: .prompt-warning }
+
+### Unpacking
+
+The most useful thing you can do with a tuple is unpack it -- assign each item to its own variable in one line. This is exactly what happens when you write `for name, score in scores.items()`.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-tuple-unpack' source='dicts-tuples-tuple-unpack' %}
+
+### Tuples vs Lists -- when to use which
+
+Both are ordered sequences. The question is whether the data is meant to change.
+
+| Use a list when... | Use a tuple when... |
+|--------------------|---------------------|
+| The collection will grow or shrink | The data is fixed and shouldn't change |
+| Order matters but items are interchangeable | Each position has a specific meaning |
+| You need `.append()`, `.remove()`, etc. | You want to signal "this is a record, not a collection" |
+
+A list of users grows over time -- you add and remove entries. A single user's coordinates `(lat, lon)` is a tuple -- those two values belong together and neither should be swapped or overwritten independently.
+
+{% include embed/python-training/python-editor.html id='dicts-tuples-tuple-vs-list' source='dicts-tuples-tuple-vs-list' %}
+
+Immutability also has a practical side effect: tuples can be used as dictionary keys, lists cannot. Dict keys must be immutable, and tuples qualify. That's what makes things like `{(0, 0): "origin", (3, 4): "point B"}` valid.
+
+---
+
+## Conclusion
+
+Lists, dictionaries, and tuples are the three workhorses of Python data. You now have all three.
+
+Dictionaries are for named data -- any time you need to look something up by a label rather than a position. When you find yourself mentally mapping list indexes to meanings, that's a dict waiting to happen. Most structured data you'll encounter in the real world -- from files, APIs, databases -- arrives as a dictionary or a list of dictionaries.
+
+Tuples are for data that belongs together and shouldn't change. They're lighter than lists and their immutability carries intent: these values are a fixed unit. You'll see them constantly as the pairs that come out of `.items()`, as return values from functions, and anywhere a record has a known, fixed shape.

--- a/_sass/addon/pyscript.scss
+++ b/_sass/addon/pyscript.scss
@@ -131,6 +131,85 @@ body > div.py-error {
 }
 
 /* -----------------------------------------------------------------------
+ * Challenge spoiler disclosure widget
+ * Usage: <details class="spoiler"><summary>Show solution</summary> ... </details>
+ * ----------------------------------------------------------------------- */
+
+details.spoiler {
+  border: 1px solid var(--language-border-color);
+  border-radius: $base-radius;
+  margin-top: 0.75rem;
+  margin-bottom: 1.2em;
+  background-color: var(--highlight-bg-color);
+  overflow: hidden;
+
+  summary {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 1rem;
+    font-family: $font-family-base;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--code-header-text-color);
+    cursor: pointer;
+    user-select: none;
+
+    /* hide the default browser disclosure triangle */
+    &::-webkit-details-marker { display: none; }
+    &::marker { display: none; }
+
+    /* chevron via pseudo-element */
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 0.5rem;
+      height: 0.5rem;
+      border-right: 2px solid currentColor;
+      border-bottom: 2px solid currentColor;
+      transform: rotate(-45deg);
+      transition: transform 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    &:hover {
+      color: var(--link-color);
+    }
+  }
+
+  &[open] > summary::before {
+    transform: rotate(45deg);
+  }
+
+  /* content area below the summary */
+  > *:not(summary) {
+    padding: 0 1rem 0.75rem;
+  }
+
+  /* section heading inside the spoiler */
+  .spoiler-section {
+    font-family: $font-family-base;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--code-header-text-color);
+    margin-top: 0.75rem;
+    margin-bottom: 0.25rem;
+  }
+
+  /* note/callout line inside the spoiler */
+  .spoiler-note {
+    font-family: $font-family-base;
+    font-size: 0.82rem;
+    color: var(--text-muted-color);
+    margin-top: 0.5rem;
+    margin-bottom: 0;
+  }
+}
+
+/* -----------------------------------------------------------------------
  * py-terminal (live MicroPython REPL)
  * ----------------------------------------------------------------------- */
 

--- a/_sass/addon/pyscript.scss
+++ b/_sass/addon/pyscript.scss
@@ -158,6 +158,7 @@ details.spoiler {
 
     /* hide the default browser disclosure triangle */
     &::-webkit-details-marker { display: none; }
+
     &::marker { display: none; }
 
     /* chevron via pseudo-element */
@@ -166,8 +167,8 @@ details.spoiler {
       display: inline-block;
       width: 0.5rem;
       height: 0.5rem;
-      border-right: 2px solid currentColor;
-      border-bottom: 2px solid currentColor;
+      border-right: 2px solid currentcolor;
+      border-bottom: 2px solid currentcolor;
       transform: rotate(-45deg);
       transition: transform 0.15s ease;
       flex-shrink: 0;


### PR DESCRIPTION
## Summary

- Adds `_drafts/2026-03-13-python-challenges.md` -- three challenge problems (FizzBuzz, Reverse a List, Grade Calculator) each with starter code and dual-solution spoilers
- Adds `_drafts/2026-03-13-python-dicts-and-tuples.md` -- teaching post covering dictionaries (with when/why motivation) and tuples, in that order
- Adds 19 new interactive editor entries to `_data/python_training_editors.yml`
- Adds `details.spoiler` CSS block to `_sass/addon/pyscript.scss` for the spoiler disclosure widget